### PR TITLE
Fit translations into single line

### DIFF
--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -161,7 +161,7 @@ html {
 .translations {
   margin: 10px auto;
   font-size: 12px;
-  width: 529px;
+  width: 553px;
   text-align: center;
   padding-left: 100px;
   padding-right: 100px;


### PR DESCRIPTION
- Increases width in translations style so all translation names fit into single line

| Before | After |
| --- | --- |
| <img width="685" alt="image" src="https://github.com/8thlight/manifesto_public/assets/54677730/95c96bd9-d967-418f-b6b7-a97a92f0b7a6"> | <img width="694" alt="image" src="https://github.com/8thlight/manifesto_public/assets/54677730/9e5a7ce8-1ee5-4339-b4b6-c7d33e4edaef"> |
